### PR TITLE
Move AdSense auto ads script into document head

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -79,6 +79,7 @@ HTML = """<!doctype html><html lang=\"en\"><head>
 <meta name=\"twitter:description\" content=\"Convert large MBOX archives to CSV spreadsheets with server-side parsing.\">
 <link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>
 <link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;800&display=swap\" rel=\"stylesheet\">
+<script async src=\"https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8714478254404273\" crossorigin=\"anonymous\"></script>
 <script type=\"application/ld+json\">
 {
   \"@context\": \"https://schema.org\",
@@ -241,7 +242,6 @@ kbd{background:#111a2e;padding:2px 6px;border-radius:6px;border:1px solid #1e293
   </header>
 
   <div class=\"ad-wrapper\" aria-label=\"Top advertisement slot\">
-    <script async src=\"https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8714478254404273\" crossorigin=\"anonymous\"></script>
     <p>Advertisements are served via Google AdSense.</p>
   </div>
 
@@ -502,7 +502,6 @@ kbd{background:#111a2e;padding:2px 6px;border-radius:6px;border:1px solid #1e293
   </main>
 
   <div class=\"ad-wrapper\" aria-label=\"Bottom advertisement slot\">
-    <script async src=\"https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8714478254404273\" crossorigin=\"anonymous\"></script>
     <p>Advertisements are served via Google AdSense.</p>
   </div>
 

--- a/app/pages/index.html
+++ b/app/pages/index.html
@@ -20,6 +20,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/app.css">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8714478254404273"
+          crossorigin="anonymous"></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -245,8 +247,6 @@
     </header>
 
     <div class="ad-wrapper" aria-label="Top advertisement slot">
-      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8714478254404273"
-              crossorigin="anonymous"></script>
       <p>Advertisements are served via Google AdSense.</p>
     </div>
 
@@ -515,8 +515,6 @@
     </main>
 
     <div class="ad-wrapper" aria-label="Bottom advertisement slot">
-      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8714478254404273"
-              crossorigin="anonymous"></script>
       <p>Advertisements are served via Google AdSense.</p>
     </div>
 


### PR DESCRIPTION
## Summary
- load the Google AdSense auto ads script from the document head in both the static homepage and FastAPI-rendered template
- remove duplicated body-level script tags, leaving only the informational wrappers for ad slots

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68e632da7f448331ae95dd145a0d9e29